### PR TITLE
부원 모집 기능 수정/추가

### DIFF
--- a/src/recruit/dto/apply.dto.ts
+++ b/src/recruit/dto/apply.dto.ts
@@ -1,15 +1,17 @@
 import { DepartmentEnum } from "./department.enum";
-import { IsBoolean, IsEmail, IsEnum, IsNumber, IsString, Length, Max, MaxLength, Min } from "class-validator";
+import { IsEnum, IsNumber, IsString, Length, Matches, Max, Min } from "class-validator";
 
 export class ApplyDto {
+  @IsString()
   @Length(8, 8)
-  studentId: number;
+  @Matches(/^[1-9]\d*$/, { message: 'studentId must not start with 0' })
+  studentId: string;
 
   @IsString()
   applicantName: string;
 
   @IsString()
-  @Length(13, 13)
+  @Length(10, 13)
   applicantContact: string;
 
   @IsEnum(DepartmentEnum)
@@ -22,6 +24,6 @@ export class ApplyDto {
   applicantGrade: number;
 
   @IsString()
-  @MaxLength(200)
+  // @MaxLength(200)
   reasonForApply: string;
 }

--- a/src/recruit/dto/result-check.dto.ts
+++ b/src/recruit/dto/result-check.dto.ts
@@ -1,0 +1,21 @@
+import { IsEnum, IsString, Length, Matches } from "class-validator";
+
+export enum CheckTypeEnum {
+  FIRST_PASS = 'FIRST_PASS',
+  SECOND_PASS = 'SECOND_PASS',
+}
+
+export class ResultCheckDto {
+  @IsEnum(CheckTypeEnum)
+  @IsString()
+  checkType: CheckTypeEnum;
+
+  @IsString()
+  @Length(8, 8)
+  @Matches(/^[1-9]\d*$/, { message: 'studentId must not start with 0' })
+  studentId: string;
+
+  @IsString()
+  @Length(4, 4)
+  contactLastDigit: string;
+}

--- a/src/recruit/dto/result.dto.ts
+++ b/src/recruit/dto/result.dto.ts
@@ -1,22 +1,27 @@
-import { IsBoolean, IsString, Length } from "class-validator";
+import { IsBoolean, IsEnum, IsString, Length } from "class-validator";
+import { CheckTypeEnum } from "./result-check.dto";
 
 export class ApplyResultDto {
-  private constructor(studentId: number, applicantName: string, isApplicantPassed: boolean) {
+  private constructor(studentId: string, applicantName: string, checkType: CheckTypeEnum, isApplicantPassed: boolean) {
     this.studentId = studentId;
     this.applicantName = applicantName;
+    this.checkType = checkType;
     this.isApplicantPassed = isApplicantPassed;
   }
 
   @Length(8, 8)
-  studentId: number;
+  studentId: string;
 
   @IsString()
   applicantName: string;
 
+  @IsEnum(CheckTypeEnum)
+  checkType: CheckTypeEnum;
+
   @IsBoolean()
   isApplicantPassed: boolean;
 
-  static create(studentId: number, applicantName: string, isApplicantPassed: boolean): ApplyResultDto {
-    return new ApplyResultDto(studentId, applicantName, isApplicantPassed);
+  static create(studentId: string, applicantName: string, checkType: CheckTypeEnum, isApplicantPassed: boolean): ApplyResultDto {
+    return new ApplyResultDto(studentId, applicantName, checkType, isApplicantPassed);
   }
 }

--- a/src/recruit/dto/result.dto.ts
+++ b/src/recruit/dto/result.dto.ts
@@ -2,11 +2,12 @@ import { IsBoolean, IsEnum, IsString, Length } from "class-validator";
 import { CheckTypeEnum } from "./result-check.dto";
 
 export class ApplyResultDto {
-  private constructor(studentId: string, applicantName: string, checkType: CheckTypeEnum, isApplicantPassed: boolean) {
+  private constructor(studentId: string, applicantName: string, checkType: CheckTypeEnum, isApplicantPassed: boolean, etc?: string) {
     this.studentId = studentId;
     this.applicantName = applicantName;
     this.checkType = checkType;
     this.isApplicantPassed = isApplicantPassed;
+    this.etc = etc;
   }
 
   @Length(8, 8)
@@ -21,7 +22,10 @@ export class ApplyResultDto {
   @IsBoolean()
   isApplicantPassed: boolean;
 
-  static create(studentId: string, applicantName: string, checkType: CheckTypeEnum, isApplicantPassed: boolean): ApplyResultDto {
-    return new ApplyResultDto(studentId, applicantName, checkType, isApplicantPassed);
+  @IsString()
+  etc?: string;
+
+  static create(studentId: string, applicantName: string, checkType: CheckTypeEnum, isApplicantPassed: boolean, etc? : string): ApplyResultDto {
+    return new ApplyResultDto(studentId, applicantName, checkType, isApplicantPassed, etc);
   }
 }

--- a/src/recruit/recruit.controller.ts
+++ b/src/recruit/recruit.controller.ts
@@ -4,6 +4,8 @@ import { ApplyDto } from "./dto/apply.dto";
 import { Recruit } from "./schema/recruit.schema";
 import { JwtAuthGuard } from "../auth/jwt/jwt.guard";
 import { ApplyResultDto } from "./dto/result.dto";
+import { ResultCheckDto } from "./dto/result-check.dto";
+import { ServiceSettingsDto } from "../service-settings/dto/service-settings.dto";
 
 @Controller('api/recruit')
 export class RecruitController {
@@ -17,9 +19,14 @@ export class RecruitController {
 
   // checkApplyResult : 합격 조회
   @Get('result')
-  checkApplyResult(@Body('studentId') studentId: number,
-                   @Body('contactLastDigit') contactLastDigit: number): Promise<ApplyResultDto> {
-    return this.recruitService.checkApplyResult(studentId, contactLastDigit);
+  checkApplyResult(@Body() resultCheckDto: ResultCheckDto): Promise<ApplyResultDto> {
+    return this.recruitService.checkApplyResult(resultCheckDto);
+  }
+
+  // getRecruitSchedule : 모집 일정 조회 (지원자용)
+  @Get('schedule')
+  getRecruitSchedule(): Promise<ServiceSettingsDto[]> {
+    return this.recruitService.getRecruitSchedule();
   }
 
   // findAll : 모든 지원자 조회

--- a/src/recruit/schema/recruit.schema.ts
+++ b/src/recruit/schema/recruit.schema.ts
@@ -11,7 +11,7 @@ export class Recruit {
   applyId: number;
 
   @Prop({ unique: true, required: true })
-  studentId: number;
+  studentId: string;
 
   @Prop({ required: true })
   applicantName: string;

--- a/src/service-settings/dto/service-info.dto.ts
+++ b/src/service-settings/dto/service-info.dto.ts
@@ -1,0 +1,19 @@
+import { IsEnum, IsOptional, IsString, Length } from "class-validator";
+
+export enum ServiceInfoEnum {
+  REC_INTERVIEW_APPLY = 'REC_INTERVIEW_APPLY', // 면접 일정 지원 URL
+}
+
+export class ServiceInfoDto {
+  @IsEnum(ServiceInfoEnum)
+  @IsString()
+  @Length(4, 20)
+  key: ServiceInfoEnum;
+
+  @IsString()
+  value: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+}

--- a/src/service-settings/schema/service-info.schema.ts
+++ b/src/service-settings/schema/service-info.schema.ts
@@ -1,0 +1,19 @@
+import { Prop, Schema, SchemaFactory } from "@nestjs/mongoose";
+import { HydratedDocument } from "mongoose";
+import { ServiceInfoEnum } from "../dto/service-info.dto";
+
+export type ServiceInfoDocument = HydratedDocument<ServiceInfo>;
+
+@Schema()
+export class ServiceInfo {
+  @Prop({ required: true, unique: true, enum: ServiceInfoEnum })
+  key: ServiceInfoEnum;
+
+  @Prop({ required: true })
+  value: string;
+
+  @Prop({ required: false })
+  description?: string;
+}
+
+export const ServiceInfoSchema = SchemaFactory.createForClass(ServiceInfo);

--- a/src/service-settings/service-settings.controller.ts
+++ b/src/service-settings/service-settings.controller.ts
@@ -3,6 +3,8 @@ import { ServiceSettingsService } from "./service-settings.service";
 import { ServiceSettingsDto } from "./dto/service-settings.dto";
 import { ServiceSettings } from "./schema/service-settings.schema";
 import { JwtAuthGuard } from "../auth/jwt/jwt.guard";
+import { ServiceInfo } from "./schema/service-info.schema";
+import { ServiceInfoDto } from "./dto/service-info.dto";
 
 @Controller('api/service')
 export class ServiceSettingsController {
@@ -43,5 +45,26 @@ export class ServiceSettingsController {
   @Delete(':key')
   removeSetting(@Param('key') key: string): Promise<object> {
     return this.serviceSettingsService.removeSetting(key);
+  }
+
+  // getServiceInfo : 서비스 정보 조회
+  @UseGuards(new JwtAuthGuard())
+  @Get('info')
+  getServiceInfo(): Promise<ServiceInfo> {
+    return this.serviceSettingsService.getServiceInfo();
+  }
+
+  // configureInfo : 서비스 정보 추가
+  @UseGuards(new JwtAuthGuard())
+  @Post('info')
+  configureServiceInfo(@Body() serviceInfoDto: ServiceInfoDto): Promise<ServiceInfo> {
+    return this.serviceSettingsService.configureServiceInfo(serviceInfoDto);
+  }
+
+  // updateInfo : 서비스 정보 수정
+  @UseGuards(new JwtAuthGuard())
+  @Patch('info')
+  updateServiceInfo(@Body() serviceInfoDto: ServiceInfoDto): Promise<ServiceInfo> {
+    return this.serviceSettingsService.updateServiceInfo(serviceInfoDto);
   }
 }

--- a/src/service-settings/service-settings.module.ts
+++ b/src/service-settings/service-settings.module.ts
@@ -3,10 +3,14 @@ import { ServiceSettingsController } from './service-settings.controller';
 import { ServiceSettingsService } from './service-settings.service';
 import { ServiceSettings, ServiceSettingsSchema } from "./schema/service-settings.schema";
 import { MongooseModule } from "@nestjs/mongoose";
+import { ServiceInfo, ServiceInfoSchema } from "./schema/service-info.schema";
 
 @Module({
   imports: [
-    MongooseModule.forFeature([{ name: ServiceSettings.name, schema: ServiceSettingsSchema}]),
+    MongooseModule.forFeature([
+      { name: ServiceSettings.name, schema: ServiceSettingsSchema},
+      { name: ServiceInfo.name, schema: ServiceInfoSchema }
+    ]),
   ],
   controllers: [ServiceSettingsController],
   providers: [ServiceSettingsService],

--- a/src/service-settings/service-settings.service.ts
+++ b/src/service-settings/service-settings.service.ts
@@ -4,10 +4,15 @@ import { ServiceSettings } from "./schema/service-settings.schema";
 import { Model } from "mongoose";
 import { ServiceSettingsDto } from "./dto/service-settings.dto";
 import * as moment from 'moment-timezone';
+import { ServiceInfo } from "./schema/service-info.schema";
+import { ServiceInfoDto, ServiceInfoEnum } from "./dto/service-info.dto";
 
 @Injectable()
 export class ServiceSettingsService {
-  constructor(@InjectModel(ServiceSettings.name) private serviceSettingsModel: Model<ServiceSettings>) {}
+  constructor(
+      @InjectModel(ServiceSettings.name) private serviceSettingsModel: Model<ServiceSettings>,
+      @InjectModel(ServiceInfo.name) private serviceInfoModel: Model<ServiceInfo>
+  ) {}
 
   // configureSetting : 설정 추가
   async configureSetting(settingData: ServiceSettingsDto): Promise<ServiceSettings> {
@@ -60,5 +65,36 @@ export class ServiceSettingsService {
   // convertUtcDateToKst : UTC 시간을 한국 시간으로 변환
   convertUtcDateToKst(date: string): string {
     return moment(date, moment.ISO_8601).tz('Asia/Seoul').format('YYYY-MM-DD HH:mm:ss');
+  }
+
+  // getServiceInfo : 서비스 정보 조회 (면접 예약 URL 반환)
+  async getServiceInfo(): Promise<ServiceInfo> {
+    const key = ServiceInfoEnum.REC_INTERVIEW_APPLY;
+    const info = await this.serviceInfoModel.findOne({ key }).exec();
+    if (!info) throw new NotFoundException('Info Not Found');
+    return info;
+  }
+
+  // configureServiceInfo : 서비스 정보 추가
+  async configureServiceInfo(serviceInfoDto: ServiceInfoDto) {
+    const info = new this.serviceInfoModel(serviceInfoDto);
+    try {
+      return await info.save();
+    } catch (error) {
+      if (error.code === 11000) {
+        throw new ConflictException('Info Already Exists');
+      } else {
+        throw new InternalServerErrorException();
+      }
+    }
+  }
+
+  // updateServiceInfo : 서비스 정보 수정
+  async updateServiceInfo(serviceInfoDto: ServiceInfoDto): Promise<ServiceInfo> {
+    const info = await this.serviceInfoModel.findOneAndUpdate(
+      { key: serviceInfoDto.key }, serviceInfoDto, { new: true, runValidators: true }
+    ).exec();
+    if (!info) throw new NotFoundException('Info Not Found');
+    return info;
   }
 }


### PR DESCRIPTION
- dto, 스키마에서의 studentId 타입 string으로 변경 (타입 검증에 유리하기 위함)
- studentId가 올바른 타입으로 전달되도록 타입 검증 정교화
- 1차 합격자, 2차 합격자 조회 기능 분리 (조회 타입을 전달받아 다르게 조회하도록 함)
- 지원자 조회용 모집 일정 조회 API 추가
- 서비스 정보 기능 구현 (1차 합격자에 한해 면접 예약 외부 URL 까지 반환하도록 구현)